### PR TITLE
Add Gnome 49 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "shell-version": [
         "46",
         "47",
-        "48"
+        "48",
+        "49"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
Update metadata to support Gnome 49. Based on the https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator/issues/549 feedback.